### PR TITLE
Update build.boot

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,9 +1,9 @@
 (set-env!
  :src-paths    #{"src"}
  :rsc-paths    #{"html"}
- :dependencies '[[adzerk/boot-cljs      "0.0-2371-22" :scope "test"]
-                 [adzerk/boot-cljs-repl "0.1.5"       :scope "test"]
-                 [adzerk/boot-reload    "0.1.3"       :scope "test"]])
+ :dependencies '[[adzerk/boot-cljs      "0.0-2371-25" :scope "test"]
+                 [adzerk/boot-cljs-repl "0.1.6"       :scope "test"]
+                 [adzerk/boot-reload    "0.1.6"       :scope "test"]])
 
 (require
  '[adzerk.boot-cljs      :refer :all]


### PR DESCRIPTION
The ealier versions of the dependencies don't work with the latest version of boot.
