### PR TITLE
Updated boot-cljs version to 0.0-2814-3

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,7 +1,7 @@
 (set-env!
  :source-paths   #{"src"}
  :resource-paths #{"html"}
- :dependencies '[[adzerk/boot-cljs      "0.0-2814-1" :scope "test"]
+ :dependencies '[[adzerk/boot-cljs      "0.0-2814-3" :scope "test"]
                  [adzerk/boot-cljs-repl "0.1.7"      :scope "test"]
                  [adzerk/boot-reload    "0.2.4"      :scope "test"]
                  [pandeiro/boot-http    "0.3.0"      :scope "test"]])


### PR DESCRIPTION
I just tried out this project and just running `boot cljs` in command-line failed due to a missing ClojureScript dependency in Clojars. Upgrading to current version solved it.

The exception I had was: 
``` 
$ boot cljs
Writing main.cljs.edn...
                                  clojure.lang.ExceptionInfo: java.util.concurrent.ExecutionException: org.sonatype.aether.resolution.DependencyResolutionException: Could not find artifact org.clojure:clojurescript:jar:0.0.0 in clojars (http://clojars.org/repo/)
    data: {:file
           "/var/folders/62/3v4gckg15t706bjzkjw155n00000gn/T/boot.user7755039389680290541.clj",
           :line 9}
                     java.util.concurrent.ExecutionException: java.util.concurrent.ExecutionException: org.sonatype.aether.resolution.DependencyResolutionException: Could not find artifact org.clojure:clojurescript:jar:0.0.0 in clojars (http://clojars.org/repo/)
                     java.util.concurrent.ExecutionException: org.sonatype.aether.resolution.DependencyResolutionException: Could not find artifact org.clojure:clojurescript:jar:0.0.0 in clojars (http://clojars.org/repo/)
org.sonatype.aether.resolution.DependencyResolutionException: Could not find artifact org.clojure:clojurescript:jar:0.0.0 in clojars (http://clojars.org/repo/)
    result: #<DependencyResult [adzerk:boot-cljs:jar:0.0-2814-1 < clojars (http://clojars.org/repo/, releases+snapshots), adzerk:boot-cljs-repl:jar:0.1.7 < clojars (http://clojars.org/repo/, releases+snapshots), adzerk:boot-reload:jar:0.2.4 < clojars (http://clojars.org/repo/, releases+snapshots), pandeiro:boot-http:jar:0.3.0 < clojars (http://clojars.org/repo/, releases+snapshots), null < null]>
  org.sonatype.aether.resolution.ArtifactResolutionException: Could not find artifact org.clojure:clojurescript:jar:0.0.0 in clojars (http://clojars.org/repo/)
     result: #<ArtifactResult adzerk:boot-cljs:jar:0.0-2814-1 < clojars (http://clojars.org/repo/, releases+snapshots)>
    results: [#<ArtifactResult adzerk:boot-cljs:jar:0.0-2814-1 < clojars (http://clojars.org/repo/, releases+snapshots)> #<ArtifactResult adzerk:boot-cljs-repl:jar:0.1.7 < clojars (http://clojars.org/repo/, releases+snapshots)> #<ArtifactResult adzerk:boot-reload:jar:0.2.4 < clojars (http://clojars.org/repo/, releases+snapshots)> #<ArtifactResult pandeiro:boot-http:jar:0.3.0 < clojars (http://clojars.org/repo/, releases+snapshots)> #<ArtifactResult null < null>]
      org.sonatype.aether.transfer.ArtifactNotFoundException: Could not find artifact org.clojure:clojurescript:jar:0.0.0 in clojars (http://clojars.org/repo/)
      artifact: #<DefaultArtifact org.clojure:clojurescript:jar:0.0.0>
    repository: #<RemoteRepository clojars (http://clojars.org/repo/, releases+snapshots)>
     org.sonatype.aether.connector.wagon.WagonRepositoryConnector$4.wrap  WagonRepositoryConnector.java: 947
     org.sonatype.aether.connector.wagon.WagonRepositoryConnector$4.wrap  WagonRepositoryConnector.java: 941
org.sonatype.aether.connector.wagon.WagonRepositoryConnector$GetTask.run  WagonRepositoryConnector.java: 669
       org.sonatype.aether.util.concurrency.RunnableErrorForwarder$1.run    RunnableErrorForwarder.java:  60
```