### PR TITLE
Upgrade to the released version of boot-http

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
     [adzerk/boot-cljs          "0.0-3308-0"      :scope "test"]
     [adzerk/boot-cljs-repl     "0.1.10-SNAPSHOT" :scope "test"]
     [adzerk/boot-reload        "0.3.1"           :scope "test"]
-    [pandeiro/boot-http        "0.6.3-SNAPSHOT"  :scope "test"]
+    [pandeiro/boot-http        "0.6.3"  :scope "test"]
     [org.clojure/clojure       "1.7.0"]
     [org.clojure/clojurescript "0.0-3308"]])
 


### PR DESCRIPTION
0.6.3 of boot-http is now released