### PR TITLE
Add test runner to project

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -6,6 +6,7 @@
     [adzerk/boot-cljs-repl       "0.1.10-SNAPSHOT" :scope "test"]
     [adzerk/boot-reload          "0.3.1"           :scope "test"]
     [pandeiro/boot-http          "0.6.3"           :scope "test"]
+    [crisptrutski/boot-cljs-test "0.1.0-SNAPSHOT"  :scope "test"]
     [org.clojure/clojure         "1.7.0"]
     [org.clojure/clojurescript   "1.7.58"]])
 
@@ -13,10 +14,17 @@
   '[adzerk.boot-cljs      :refer [cljs]]
   '[adzerk.boot-cljs-repl :refer [cljs-repl start-repl]]
   '[adzerk.boot-reload    :refer [reload]]
+  '[crisptrutski.boot-cljs-test  :refer [test-cljs]]
   '[pandeiro.boot-http    :refer [serve]])
 
-(deftask dev []
+(deftask auto-test []
   (set-env! :source-paths #{"src" "test"})
+  (comp (watch)
+        (speak)
+        (test-cljs)))
+
+(deftask dev []
+  (set-env! :source-paths #{"src"})
   (comp (serve :dir "target/")
         (watch)
         (speak)

--- a/build.boot
+++ b/build.boot
@@ -2,12 +2,12 @@
   :source-paths   #{"src"}
   :resource-paths #{"html"}
   :dependencies '[
-    [adzerk/boot-cljs          "0.0-3308-0"      :scope "test"]
-    [adzerk/boot-cljs-repl     "0.1.10-SNAPSHOT" :scope "test"]
-    [adzerk/boot-reload        "0.3.1"           :scope "test"]
-    [pandeiro/boot-http        "0.6.3-SNAPSHOT"  :scope "test"]
-    [org.clojure/clojure       "1.7.0"]
-    [org.clojure/clojurescript "0.0-3308"]])
+    [adzerk/boot-cljs            "0.0-3308-0"      :scope "test"]
+    [adzerk/boot-cljs-repl       "0.1.10-SNAPSHOT" :scope "test"]
+    [adzerk/boot-reload          "0.3.1"           :scope "test"]
+    [pandeiro/boot-http          "0.6.3"           :scope "test"]
+    [org.clojure/clojure         "1.7.0"]
+    [org.clojure/clojurescript   "1.7.58"]])
 
 (require
   '[adzerk.boot-cljs      :refer [cljs]]


### PR DESCRIPTION
Note that I've put the test in a separate task - waiting for the next release of `boot-cljs` before improving the story of combining it into other builds.